### PR TITLE
CoartLipSync: finally fixed zero-word edge case (now works always); IpaacaIUAdapter: better logging

### DIFF
--- a/BMLAdapters/AsapIpaacaIURealizerAdapters/src/asap/ipaacaiuadapters/IpaacaToBMLRealizerAdapter.java
+++ b/BMLAdapters/AsapIpaacaIURealizerAdapters/src/asap/ipaacaiuadapters/IpaacaToBMLRealizerAdapter.java
@@ -33,6 +33,9 @@ import asap.realizerport.RealizerPort;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * New bridge between ipaaca and ASAPrealizer, unifying request and feedback
  * into persistent IUs. Replacement for initial ipaaca adapter by Herwin.
@@ -46,6 +49,8 @@ public class IpaacaToBMLRealizerAdapter implements BMLFeedbackListener
     {
         Initializer.initializeIpaacaRsb();
     }
+    
+	private Logger logger = LoggerFactory.getLogger(IpaacaToBMLRealizerAdapter.class.getName());
     
     private final InputBuffer inBuffer = new InputBuffer(
     	"IpaacaToBMLRealizerAdapter", 
@@ -116,6 +121,7 @@ public class IpaacaToBMLRealizerAdapter implements BMLFeedbackListener
 					}
 					
 					if (has_errors) {
+						logger.warn("Error (notifying over ipaaca): {}", error_string);
 						items.put(IpaacaBMLConstants.IU_STATUS_KEY, "ERROR");
 						items.put(IpaacaBMLConstants.IU_ERROR_KEY, error_string);
 					} else {
@@ -150,6 +156,7 @@ public class IpaacaToBMLRealizerAdapter implements BMLFeedbackListener
 							}
 						} catch (Exception e) {
 							error_string = "Exception during BML parse or perform: "+getExceptionStackTrace(e);
+							logger.warn("Error (notifying over ipaaca): {}", error_string);
 							items.put(IpaacaBMLConstants.IU_STATUS_KEY, "ERROR");
 							items.put(IpaacaBMLConstants.IU_ERROR_KEY, error_string);
 						}

--- a/Engines/AsapFaceEngine/src/asap/faceengine/lipsync/CoarticulationLipSyncProvider.java
+++ b/Engines/AsapFaceEngine/src/asap/faceengine/lipsync/CoarticulationLipSyncProvider.java
@@ -128,35 +128,42 @@ public class CoarticulationLipSyncProvider implements LipSynchProvider
         }
 
         // A increasing number for the overall amount of phonemes in the current sequence
-        int currentPhonemeAmount = wordDescriptions.get(0).getPhonemes().size();
-        phonemesOfSequence = new ArrayList<>(wordDescriptions.get(0).getPhonemes());
-        numbersOfFirstPhonemes.add(0);
-        numbersOfLastPhonemes.add(currentPhonemeAmount - 1);
+        int currentPhonemeAmount = 0;
+        phonemesOfSequence = new ArrayList<>();
+        
+        if (wordDescriptions.size()>0) {
+            currentPhonemeAmount = wordDescriptions.get(0).getPhonemes().size();
+            phonemesOfSequence =  new ArrayList<>(wordDescriptions.get(0).getPhonemes());
+        
+            
+            numbersOfFirstPhonemes.add(0);
+            numbersOfLastPhonemes.add(currentPhonemeAmount - 1);
 
-        // Create the sequence of all phonemes as a list and fill the lists with the numbers of the first and last phonemes in the words of the sequence
-        for (WordDescription wd : wordDescriptions)
-        {
-
-            if (ACTIVATEOUTPUTS) System.out.print("--- Added " + wd.getPhonemes().size() + " new phonemes ---   ");
-
-            for (Phoneme p : wd.getPhonemes())
+            // Create the sequence of all phonemes as a list and fill the lists with the numbers of the first and last phonemes in the words of the sequence
+            for (WordDescription wd : wordDescriptions)
             {
-                if (ACTIVATEOUTPUTS) System.out.print(PhonemeUtil.phonemeIntToString(p.getNumber()));
-                if (p != wd.getPhonemes().get(wd.getPhonemes().size() - 1)) if (ACTIVATEOUTPUTS) System.out.print(", ");
+
+                if (ACTIVATEOUTPUTS) System.out.print("--- Added " + wd.getPhonemes().size() + " new phonemes ---   ");
+
+                for (Phoneme p : wd.getPhonemes())
+                {
+                    if (ACTIVATEOUTPUTS) System.out.print(PhonemeUtil.phonemeIntToString(p.getNumber()));
+                    if (p != wd.getPhonemes().get(wd.getPhonemes().size() - 1)) if (ACTIVATEOUTPUTS) System.out.print(", ");
+                }
+
+                if (wd != wordDescriptions.get(0))
+                {
+                    phonemesOfSequence.addAll(wd.getPhonemes());
+
+                    numbersOfFirstPhonemes.add(currentPhonemeAmount);
+
+                    currentPhonemeAmount += wd.getPhonemes().size();
+
+                    numbersOfLastPhonemes.add(currentPhonemeAmount - 1);
+
+                }
+                if (ACTIVATEOUTPUTS) System.out.println("");
             }
-
-            if (wd != wordDescriptions.get(0))
-            {
-                phonemesOfSequence.addAll(wd.getPhonemes());
-
-                numbersOfFirstPhonemes.add(currentPhonemeAmount);
-
-                currentPhonemeAmount += wd.getPhonemes().size();
-
-                numbersOfLastPhonemes.add(currentPhonemeAmount - 1);
-
-            }
-            if (ACTIVATEOUTPUTS) System.out.println("");
         }
 
         if (ACTIVATEOUTPUTS)


### PR DESCRIPTION
CoarticulationLipSyncProvider used to fail when empty &lt;speech&gt;&lt;text&gt; provided. This has been circumvented, now autogenerated templates won't crash the realizer in that case (and in fact produce all other specified modalities successfully).
