### PR TITLE
optional undefinedPartsToIdentity attribute for restposes

### DIFF
--- a/Engines/Animation/AsapAnimationEngine/src/asap/animationengine/gesturebinding/RestPoseAssembler.java
+++ b/Engines/Animation/AsapAnimationEngine/src/asap/animationengine/gesturebinding/RestPoseAssembler.java
@@ -51,7 +51,9 @@ public class RestPoseAssembler extends XMLStructureAdapter
             {
                 throw new XMLScanException("Error reading skeletonpose file " + file, e);
             }
-            restPose = new SkeletonPoseRestPose(pose);
+
+        	boolean undefinedPartsToIdentity = getOptionalBooleanAttribute("undefinedPartsToIdentity", attrMap, true);
+            restPose = new SkeletonPoseRestPose(pose, undefinedPartsToIdentity);
         }
         else if (type.equals("class"))
         {

--- a/Engines/Animation/AsapAnimationEngine/src/asap/animationengine/restpose/SkeletonPoseRestPose.java
+++ b/Engines/Animation/AsapAnimationEngine/src/asap/animationengine/restpose/SkeletonPoseRestPose.java
@@ -38,15 +38,23 @@ public class SkeletonPoseRestPose implements RestPose
     private AnimationPlayer player;
     private VJoint poseTree;        //Holds the pose on a VJoint structure. Joints not in the pose are set to have identity rotation.
     private SkeletonPose pose;
-
+    private boolean undefinedPartsToIdentity;
+    
     public SkeletonPoseRestPose()
     {
-
+        this.undefinedPartsToIdentity = true;
     }
-
+    
+    public SkeletonPoseRestPose(SkeletonPose pose, boolean unsetToIdentity)
+    {
+        this.pose = pose;
+        this.undefinedPartsToIdentity = unsetToIdentity;
+    }
+    
     public SkeletonPoseRestPose(SkeletonPose pose)
     {
         this.pose = pose;
+        this.undefinedPartsToIdentity = true;
     }
 
     public void setAnimationPlayer(AnimationPlayer player)
@@ -55,7 +63,7 @@ public class SkeletonPoseRestPose implements RestPose
         poseTree = player.getVCurr().copyTree("rest-");
         for (VJoint vj : poseTree.getParts())
         {
-            if (vj.getSid() != null)
+            if (undefinedPartsToIdentity && vj.getSid() != null)
             {
                 vj.setRotation(Quat4f.getIdentity());
             }


### PR DESCRIPTION
Using SkeletonRestPoses as start/restpose sets all parts not specified in that pose to identity rotation. With this patch this behavior can be disabled, i.e. in agentspec:

```xml
<Loader id="animationengine" loader="asap.animationengine.loader.MixedAnimationEngineLoader"  ...>
  <GestureBinding ... />
  <StartPose>
    <RestPose type="SkeletonPose" file="sitting_pose.xml" undefinedPartsToIdentity="false" />
  </StartPose>
</Loader>
```

In multi-agent setups, this allows us to set different starting poses per agent when initializating the SkeletonEmbodiment, and not have them overridden when setting the restpose.